### PR TITLE
adding docker file and info in readme for using them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use the official Golang image as the base image
+FROM golang:1.14
+
+# Set the working directory
+WORKDIR /go/src/app
+
+COPY go.mod go.sum ./
+
+# Download dependencies using Go modules
+RUN go get -d ./...
+
+COPY . .
+
+# Build the Call API tools and place them in the /go/bin directory
+RUN GOBIN=/usr/bin make install
+
+# Expose the WebSocket port
+EXPOSE 5059
+
+# Default is 'call-api' when the container starts
+# to run the others, simply override the CMD
+# docker run call-api-client
+# docker run call-cmd
+CMD ["call-api"]

--- a/README.md
+++ b/README.md
@@ -154,3 +154,30 @@ go run cmd/call-cmd/main.go CallStart caller=sip:alice@localhost callee=sip:bob@
 ## Documentation
 
 The [docs](docs/) folder contains the documentation for this project.
+
+## Build and run docker containers
+
+You can build and run the three tools under a docker container.
+
+```sh
+docker build -t opensips-call-api:latest .
+```
+
+By default the `call-api` will be run:
+
+```sh
+> docker run opensips-call-api:latest
+time="2023-10-10T21:42:48Z" level=info msg="Listening for JSON-RPC over WebSocket on localhost:5059/call-api ..."
+```
+
+But, you can specify the `call-cmd` and `call-api-client` tools:
+
+```sh
+docker run opensips-call-api:latest call-api-client \
+  -method CallStart \
+  -params '{"caller": "sip:alice@localhost", "callee": "sip:bob@localhost"}'
+```
+
+```bash
+docker run opensips-call-api:latest call-cmd CallStart caller=sip:alice@localhost callee=sip:bob@localhost
+```


### PR DESCRIPTION
I added a Dockerfile to make it easy to build a container with the three tools available. It will default to running the `call-api`. I also updated the README with info on how to do it.

It would probably be good to add info on how to pass in a custom config yaml file at run time with the container. Otherwise, people will be stuck with the default config that is build with make install.